### PR TITLE
Fix nix build with nix-diff-0.1.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -31,7 +31,12 @@ rustPlatform.buildRustPackage {
   __structuredAttrs = true;
   strictDeps = true;
 
-  cargoLock.lockFile = ./Cargo.lock;
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+    outputHashes = {
+      "nix-diff-0.1.0" = "sha256-heUqcAnGmMogyVXskXc4FMORb8ZaK6vUX+mMOpbfSUw=";
+    };
+  };
 
   nativeBuildInputs = [
     pkg-config
@@ -43,7 +48,7 @@ rustPlatform.buildRustPackage {
     zlib
     protobuf
 
-    nixVersions.nix_2_29
+    nixVersions.nix_2_32
     nlohmann_json
     libsodium
     boost


### PR DESCRIPTION
The header include for `<nix/store/export-import.hh>` requires nix 2.32.

This does not resolve the test failures.

```

running 41 tests
test cfg::tests::test_missing_profile_returns_error ... ok
test cfg::tests::test_missing_secret_key_returns_error ... ok
test cfg::tests::test_presigned_url_expiry_validation ... ok
test cfg::tests::test_parsing_profile_with_spaces_and_comments ... ok
test cfg::tests::test_parsing_default_profile_works ... ok
test cfg::tests::test_profile_with_special_characters ... ok
test cfg::tests::test_missing_access_key_returns_error ... ok
test cfg::tests::test_empty_credentials_file_returns_error ... ok
test cfg::tests::test_s3_cache_config_builder_methods ... ok
test cfg::tests::test_s3_cache_config_chaining ... ok
test cfg::tests::test_s3_cache_config_from_str_case_insensitive ... ok
test cfg::tests::test_s3_cache_config_from_str_basic ... ok
test cfg::tests::test_s3_cache_config_from_str_empty_query_params ... ok
test cfg::tests::test_s3_cache_config_from_str_errors ... ok
test cfg::tests::test_s3_cache_config_from_str_multiple_same_params ... FAILED
test cfg::tests::test_s3_cache_config_from_str_with_parameters ... ok
test cfg::tests::test_s3_cache_config_from_str_with_whitespace ... ok
test cfg::tests::test_s3_client_config_new ... ok
test cfg::tests::test_s3_cache_config_new_default_values ... ok
test cfg::tests::test_s3_cache_config_presigned_url_expiry_boundaries ... ok
test cfg::tests::test_s3_client_config_builder ... ok
test cfg::tests::test_s3_scheme_from_str ... ok
test debug_info::tests::test_debug_info_link_serialization ... ok
test cfg::tests::test_s3_cache_config_from_str_with_secret_keys ... ok
test debug_info::tests::test_find_debug_files_empty_directory ... ok
test streaming_hash::tests::test_hashing_reader_different_data_patterns ... ok
test streaming_hash::tests::test_hashing_reader_empty_data ... ok
test streaming_hash::tests::test_hashing_reader_exact_buffer_size ... ok
test streaming_hash::tests::test_hashing_reader_finalize_before_completion ... ok
test debug_info::tests::test_find_debug_files ... ok
test debug_info::tests::test_find_debug_files_mixed_valid_invalid ... ok
test debug_info::tests::test_find_debug_files_invalid_structure ... ok
test streaming_hash::tests::test_hashing_reader_finalize_partial_read ... ok
test streaming_hash::tests::test_hashing_reader_partial_reads ... ok
test streaming_hash::tests::test_hashing_reader_with_async_stream ... ok
test streaming_hash::tests::test_hashing_reader_small_data ... ok
terminate called after throwing an instance of 'nix::SysError'
  what():  error: creating directory '/nix/var/nix/profiles': Permission denied
terminate called recursively
error: test failed, to rerun pass `-p binary-cache --lib`

Caused by:
  process didn't exit successfully: `/build/v3c5a0hxrjaq8xzsvcfynnw1v7s1d9jc-source/target/aarch64-unknown-linux-gnu/release/deps/binary_cache-41b2dab5630bcb5b` (signal: 6, SIGABRT: process abort signal)
```