### PR TITLE
fix: update postgresql port reference

### DIFF
--- a/runner-module.nix
+++ b/runner-module.nix
@@ -280,7 +280,7 @@ in
         StateDirectoryMode = "0700";
         ReadWritePaths = [
           "/nix/var/nix/gcroots/"
-          "/run/postgresql/.s.PGSQL.${toString config.services.postgresql.port}"
+          "/run/postgresql/.s.PGSQL.${toString config.services.postgresql.settings.port}"
           "/nix/var/nix/daemon-socket/socket"
           "/var/lib/hydra/build-logs/"
         ];


### PR DESCRIPTION
Follows the rename into the settings attribute.

> Obsolete option `services.postgresql.port` is used. It was renamed to `services.postgresql.settings.port`.