### PR TITLE
fix: support non-local postgres in runner module

### DIFF
--- a/runner-module.nix
+++ b/runner-module.nix
@@ -282,7 +282,8 @@ in
         StateDirectoryMode = "0700";
         ReadWritePaths = [
           "/nix/var/nix/gcroots/"
-          "/run/postgresql/.s.PGSQL.${toString config.services.postgresql.settings.port}"
+          # PostgreSQL database host can be non-local
+          "-/run/postgresql/.s.PGSQL.${toString config.services.postgresql.settings.port}"
           "/nix/var/nix/daemon-socket/socket"
           "/var/lib/hydra/build-logs/"
         ];


### PR DESCRIPTION
In the case of a remote database server there is no /run/postgresql path that could be made writable, so allow the service to skip the path if it does not exist.