### PR TITLE
fix: darwin build dir threshold config

### DIFF
--- a/darwin-builder-module.nix
+++ b/darwin-builder-module.nix
@@ -41,8 +41,8 @@ in
         default = 4;
       };
 
-      tmpAvailThreshold = lib.mkOption {
-        description = "Threshold in percent for /tmp before jobs are no longer scheduled on the machine";
+      buildDirAvailThreshold = lib.mkOption {
+        description = "Threshold in percent for nix build dir before jobs are no longer scheduled on the machine";
         type = lib.types.float;
         default = 10.0;
       };
@@ -162,8 +162,8 @@ in
               cfg.speedFactor
               "--max-jobs"
               cfg.maxJobs
-              "--tmp-avail-threshold"
-              cfg.tmpAvailThreshold
+              "--build-dir-avail-threshold"
+              cfg.buildDirAvailThreshold
               "--store-avail-threshold"
               cfg.storeAvailThreshold
               "--load1-threshold"


### PR DESCRIPTION
Was migrated from tmp to build-dir mid december[1].

[1] 2849036848557859b502edb64bb42e1a70154e8a